### PR TITLE
NOISSUE - Use message instead of error in JSON encoding

### DIFF
--- a/pkg/http/errors.go
+++ b/pkg/http/errors.go
@@ -24,7 +24,7 @@ func (hpe *httpProxyError) Error() string {
 
 func (hpe *httpProxyError) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
-		Error string `json:"error"`
+		Error string `json:"message"`
 	}{
 		Error: hpe.err.Error(),
 	})


### PR DESCRIPTION
### What does this do?
This PR fixes JSON encoding of the error.

### Which issue(s) does this PR fix/relate to?
There is no such issue.

### List any changes that modify/break current functionality
The response error returns the `message` instead of `error` field.

### Have you included tests for your changes?
N/A

### Did you document any new/modified functionality?
N/A

### Notes
N/A