### PR TITLE
NOISSUE - Add AuthPublish to HTTP stream

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -105,6 +105,11 @@ func (p Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		p.logger.Error("Failed to authorize connect", slog.Any("error", err))
 		return
 	}
+	if err := p.session.AuthPublish(ctx, &r.RequestURI, &payload); err != nil {
+		encodeError(w, http.StatusForbidden, err)
+		p.logger.Error("Failed to authorize publish", slog.Any("error", err))
+		return
+	}
 	if err := p.session.Publish(ctx, &r.RequestURI, &payload); err != nil {
 		encodeError(w, http.StatusBadRequest, err)
 		p.logger.Error("Failed to publish", slog.Any("error", err))


### PR DESCRIPTION


### What does this do?
This pr adds the `AuthPublish` method from the handler to the HTTP stream
### Which issue(s) does this PR fix/relate to?

Related Issue #https://github.com/absmach/supermq/issues/2800
### List any changes that modify/break current functionality
None
### Have you included tests for your changes?
No
### Did you document any new/modified functionality?

### Notes